### PR TITLE
assertEntityPattern(): php8.1: no required parameter after optional

### DIFF
--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -115,10 +115,10 @@ class PathPatternTestHelper extends BackdropWebTestCase {
     return $term;
   }
 
-  function assertEntityPattern($entity_type, $bundle, $language = LANGUAGE_NONE, $expected) {
+  function assertEntityPattern($entity_type, $bundle, $langcode, $expected) {
     backdrop_static_reset('path_get_pattern_by_entity_type');
     $this->refreshVariables();
-    $pattern = path_get_pattern_by_entity_type($entity_type, $bundle, $language);
+    $pattern = path_get_pattern_by_entity_type($entity_type, $bundle, $langcode);
     $this->assertIdentical($expected, $pattern);
   }
 


### PR DESCRIPTION
See:
- https://php.watch/versions/8.0/deprecate-required-param-after-optional
- https://www.drupal.org/i/3187744
- https://git.drupalcode.org/project/pathauto/-/commit/43c8079eacd2cecb47f93aa33b845621a5f0bead

There's 5 instances of this function in Backdrop, all inside `path_pattern.test`:
- 1 instance is the function declaration itself
- 2 instances in `testEntityBundleRenamingDeleting()` already have `$language` defined
- another 2 instances again in `testEntityBundleRenamingDeleting()` already have `$language` defined, but are commented out